### PR TITLE
docs: add traceability notes for Issue #3 (trust extension)

### DIFF
--- a/docs/traceability/issue-3-trust-extension.md
+++ b/docs/traceability/issue-3-trust-extension.md
@@ -1,0 +1,35 @@
+# Issue #3: Trust extension module
+
+## Intent
+Introduce a structured trust modeling extension that allows trust levels to be explicitly represented and validated within the Beast Mode ecosystem.
+
+## Context
+As the ecosystem expanded beyond basic Agent–Capability–Task modeling, we introduced a trust layer to support reasoning about reliability and confidence.
+
+This extension provides a formal structure for modeling trust-related properties and validating them using SHACL.
+
+## What Changed (Implementation Summary)
+- Added trust extension module:
+  - ontologies/extensions/beast_trust_ext.ttl
+- Defined trust-related property semantics (e.g., trustLevel)
+- Added SHACL constraints validating trust structure
+- Provided a validated example demonstrating correct usage
+
+## Primary Review Cues (Fast Skim)
+Please review:
+
+- ontologies/extensions/beast_trust_ext.ttl
+- SHACL shapes defined within the trust extension
+- examples/trust/trust_example.ttl
+- examples/trust/README.md (if applicable)
+
+## Implementation Anchor
+Primary commit implementing this work:
+
+- 0657661  
+  "Add trust extension with validated example"
+
+## Traceability Map
+Issue → Concept → Commit → Files
+
+This document exists to provide clear linkage between the conceptual issue and its concrete implementation anchor.

--- a/docs/traceability/issue-3-trust-extension.md
+++ b/docs/traceability/issue-3-trust-extension.md
@@ -44,11 +44,15 @@ Primary commit implementing this work:
 
 ## Traceability Map
 
-| Concept                     | Commit   |
+## Traceability Map
+
+| Concept                    | Commit   |
 |----------------------------|----------|
 | Trust extension module     | 0657661  |
 | Trust property semantics   | 0657661  |
 | SHACL validation structure | 0657661  |
 | Example usage              | 0657661  |
+
+This document links the conceptual Issue directly to its immutable implementation commit.
 
 This document links the conceptual Issue directly to its immutable implementation commit.

--- a/docs/traceability/issue-3-trust-extension.md
+++ b/docs/traceability/issue-3-trust-extension.md
@@ -16,6 +16,7 @@ This extension provides a formal structure for modeling trust-related properties
 - Provided a validated example demonstrating correct usage
 
 ## Primary Review Cues (Fast Skim)
+
 Please review:
 
 - ontologies/extensions/beast_trust_ext.ttl

--- a/docs/traceability/issue-3-trust-extension.md
+++ b/docs/traceability/issue-3-trust-extension.md
@@ -12,11 +12,9 @@ This work formalizes trust-related properties and validates them using SHACL.
 
 ## What Changed (Implementation Summary)
 
-Implemented in commit `0657661` on branch `feature/trust-extension` (pending merge into main):
+Implemented in commit:
 
-- `ontologies/extensions/beast_trust_ext.ttl`
-- `examples/trust/README.md`
-- `examples/trust/trust_example.ttl`
+`06576615c556265111c69915e5a530e173603c15`
 
 This commit introduces:
 
@@ -27,13 +25,15 @@ This commit introduces:
 
 ## Primary Review Cues (Fast Skim)
 
-Please review:
+Please review the implementation commit directly:
 
-- Commit `0657661`
-- Ontology extension file: `ontologies/extensions/beast_trust_ext.ttl`
-- Example usage under `examples/trust/`
+- Commit: https://github.com/louspringer/Beast-mode-Ontology/commit/06576615c556265111c69915e5a530e173603c15
 
-Note: These files currently exist on branch `feature/trust-extension` and are not yet merged into `main`.
+This provides stable access to:
+
+- Trust extension ontology file
+- Example TTL
+- SHACL validation definitions
 
 ## Implementation Anchor
 
@@ -44,10 +44,11 @@ Primary commit implementing this work:
 
 ## Traceability Map
 
-| Concept                     | Commit   | File(s) |
-|----------------------------|----------|---------|
-| Trust extension module     | 0657661  | ontologies/extensions/beast_trust_ext.ttl |
-| Trust example              | 0657661  | examples/trust/trust_example.ttl |
-| SHACL validation structure | 0657661  | ontologies/extensions/beast_trust_ext.ttl |
+| Concept                     | Commit   |
+|----------------------------|----------|
+| Trust extension module     | 0657661  |
+| Trust property semantics   | 0657661  |
+| SHACL validation structure | 0657661  |
+| Example usage              | 0657661  |
 
-This document links the conceptual Issue to its concrete implementation artifacts.
+This document links the conceptual Issue directly to its immutable implementation commit.

--- a/docs/traceability/issue-3-trust-extension.md
+++ b/docs/traceability/issue-3-trust-extension.md
@@ -8,33 +8,46 @@ Introduce a structured trust modeling extension that allows trust levels to be e
 
 As the ecosystem expanded beyond basic Agent–Capability–Task modeling, a trust layer was introduced to support reasoning about reliability and confidence.
 
-This extension provides a formal structure for modeling trust-related properties and validating them using SHACL.
+This work formalizes trust-related properties and validates them using SHACL.
 
 ## What Changed (Implementation Summary)
 
-- Added trust extension module:
-  - `ontologies/extensions/beast_trust_ext.ttl`
-- Defined trust-related property semantics (e.g., `trustLevel`)
-- Added SHACL constraints validating trust structure
-- Included validated example usage within the extension module
+Implemented in commit `0657661` on branch `feature/trust-extension` (pending merge into main):
+
+- `ontologies/extensions/beast_trust_ext.ttl`
+- `examples/trust/README.md`
+- `examples/trust/trust_example.ttl`
+
+This commit introduces:
+
+- Trust extension ontology module
+- Trust-related property semantics (e.g., `trustLevel`)
+- SHACL constraints validating trust structure
+- A validated example demonstrating correct usage
 
 ## Primary Review Cues (Fast Skim)
 
 Please review:
 
-- Trust extension ontology module: `ontologies/extensions/beast_trust_ext.ttl`
-- Associated SHACL shapes and validation constraints in that module
-- Structural alignment with the core Agent–Capability–Task model
+- Commit `0657661`
+- Ontology extension file: `ontologies/extensions/beast_trust_ext.ttl`
+- Example usage under `examples/trust/`
+
+Note: These files currently exist on branch `feature/trust-extension` and are not yet merged into `main`.
 
 ## Implementation Anchor
 
 Primary commit implementing this work:
 
-- 0657661  
+- 06576615c556265111c69915e5a530e173603c15  
   "Add trust extension with validated example"
 
 ## Traceability Map
 
-Issue → Concept → Commit → Files
+| Concept                     | Commit   | File(s) |
+|----------------------------|----------|---------|
+| Trust extension module     | 0657661  | ontologies/extensions/beast_trust_ext.ttl |
+| Trust example              | 0657661  | examples/trust/trust_example.ttl |
+| SHACL validation structure | 0657661  | ontologies/extensions/beast_trust_ext.ttl |
 
-This document exists to provide clear linkage between the conceptual issue and its concrete implementation anchor.
+This document links the conceptual Issue to its concrete implementation artifacts.

--- a/docs/traceability/issue-3-trust-extension.md
+++ b/docs/traceability/issue-3-trust-extension.md
@@ -1,36 +1,40 @@
 # Issue #3: Trust extension module
 
 ## Intent
+
 Introduce a structured trust modeling extension that allows trust levels to be explicitly represented and validated within the Beast Mode ecosystem.
 
 ## Context
-As the ecosystem expanded beyond basic Agent–Capability–Task modeling, we introduced a trust layer to support reasoning about reliability and confidence.
+
+As the ecosystem expanded beyond basic Agent–Capability–Task modeling, a trust layer was introduced to support reasoning about reliability and confidence.
 
 This extension provides a formal structure for modeling trust-related properties and validating them using SHACL.
 
 ## What Changed (Implementation Summary)
+
 - Added trust extension module:
-  - ontologies/extensions/beast_trust_ext.ttl
-- Defined trust-related property semantics (e.g., trustLevel)
+  - `ontologies/extensions/beast_trust_ext.ttl`
+- Defined trust-related property semantics (e.g., `trustLevel`)
 - Added SHACL constraints validating trust structure
-- Provided a validated example demonstrating correct usage
+- Included validated example usage within the extension module
 
 ## Primary Review Cues (Fast Skim)
 
 Please review:
 
-- ontologies/extensions/beast_trust_ext.ttl
-- SHACL shapes defined within the trust extension
-- examples/trust/trust_example.ttl
-- examples/trust/README.md (if applicable)
+- Trust extension ontology module: `ontologies/extensions/beast_trust_ext.ttl`
+- Associated SHACL shapes and validation constraints in that module
+- Structural alignment with the core Agent–Capability–Task model
 
 ## Implementation Anchor
+
 Primary commit implementing this work:
 
 - 0657661  
   "Add trust extension with validated example"
 
 ## Traceability Map
+
 Issue → Concept → Commit → Files
 
 This document exists to provide clear linkage between the conceptual issue and its concrete implementation anchor.

--- a/docs/traceability/issue-3-trust-extension.md
+++ b/docs/traceability/issue-3-trust-extension.md
@@ -25,11 +25,11 @@ This commit introduces:
 
 ## Primary Review Cues (Fast Skim)
 
-Please review the implementation commit directly:
+Please review commit:
 
-- Commit: https://github.com/louspringer/Beast-mode-Ontology/commit/06576615c556265111c69915e5a530e173603c15
+`06576615c556265111c69915e5a530e173603c15`
 
-This provides stable access to:
+This commit contains:
 
 - Trust extension ontology file
 - Example TTL
@@ -44,15 +44,11 @@ Primary commit implementing this work:
 
 ## Traceability Map
 
-## Traceability Map
-
-| Concept                    | Commit   |
-|----------------------------|----------|
-| Trust extension module     | 0657661  |
-| Trust property semantics   | 0657661  |
-| SHACL validation structure | 0657661  |
-| Example usage              | 0657661  |
-
-This document links the conceptual Issue directly to its immutable implementation commit.
+| Concept                    | Commit                                       |
+|----------------------------|----------------------------------------------|
+| Trust extension module     | 06576615c556265111c69915e5a530e173603c15     |
+| Trust property semantics   | 06576615c556265111c69915e5a530e173603c15     |
+| SHACL validation structure | 06576615c556265111c69915e5a530e173603c15     |
+| Example usage              | 06576615c556265111c69915e5a530e173603c15     |
 
 This document links the conceptual Issue directly to its immutable implementation commit.


### PR DESCRIPTION
Closes #3

## Intent
Provide traceability between Issue #3 and the implementation of the trust extension module.

This PR does not modify ontology logic. It adds structured review notes to make it easy to locate and skim the relevant implementation.

## What this PR adds
- docs/traceability/issue-3-trust-extension.md
- Implementation anchor: commit 0657661

## Review cues (fast skim)
- ontologies/extensions/beast_trust_ext.ttl
- SHACL shapes in the trust extension
- examples/trust/trust_example.ttl