### PR TITLE
docs: add traceability notes for Issue #9 (bow-tie messaging + network modules)

### DIFF
--- a/docs/traceability/issue-9-bowtie-messaging.md
+++ b/docs/traceability/issue-9-bowtie-messaging.md
@@ -1,0 +1,36 @@
+# Issue #9: Bow-tie messaging + network modules
+
+## Intent
+Introduce a “bow-tie” messaging structure and associated network modules, enriched to align with beast-mailbox-core semantics for clearer message flow modeling and modularity.
+
+## Context
+As messaging capabilities expanded, we needed a more organized semantic structure to represent:
+- messaging flow patterns
+- network-related concepts
+- consistent alignment with mailbox semantics (beast-mailbox-core)
+
+This improves reasoning clarity and keeps messaging components modular and reviewable.
+
+## What Changed (Implementation Summary)
+- Added/organized bow-tie messaging module(s)
+- Added/organized network module(s)
+- Enriched messaging semantics to align with beast-mailbox-core concepts
+- Added/updated any associated validation constraints (if applicable)
+
+## Primary Review Cues (Fast Skim)
+Please focus on:
+- Ontology module(s) defining bow-tie messaging structure
+- Network module(s) introduced/updated alongside messaging
+- Places where mailbox semantics are referenced/enriched
+- Any SHACL shapes validating messaging/network structure (if present)
+
+## Implementation Anchor
+Primary commit implementing this work:
+
+- 3a3d398  
+  "Add bow-tie messaging + network modules and enrich with beast-mailbox-core semantics"
+
+## Traceability Map
+Issue → Concept → Commit → Files
+
+This document exists to make review fast and to map Issue #9 to its implementation anchor.

--- a/docs/traceability/issue-9-bowtie-messaging.md
+++ b/docs/traceability/issue-9-bowtie-messaging.md
@@ -2,19 +2,15 @@
 
 ## Intent
 
-Document the bow-tie messaging and network module enhancements previously implemented in the referenced commit, ensuring clear traceability between the conceptual messaging architecture and its concrete implementation.
+Document the bow-tie messaging and network module enhancements implemented in the referenced commit, ensuring clear traceability between the conceptual messaging architecture and its concrete ontology artifacts.
 
 ## Context
 
-As Beast Mode messaging evolved, the system required a more structured representation of message flow, network semantics, and alignment with mailbox-core concepts. The referenced implementation commit introduces bow-tie messaging constructs and associated network modules to formalize these semantics.
+As Beast Mode messaging evolved, the system required a more structured representation of message flow, network semantics, and alignment with mailbox-core concepts. The referenced implementation formalizes these constructs within dedicated messaging and network modules.
 
 ## What Changed (Implementation Summary)
 
-The referenced implementation commit:
-
-`3a3d39838f93b50ec7d76074bf68d825d2f7e523`
-
-Introduces:
+The referenced implementation introduces:
 
 - Bow-tie messaging constructs for structured message flow modeling
 - Network module additions aligned with messaging semantics
@@ -24,29 +20,26 @@ This PR adds traceability documentation only and does not modify ontology logic.
 
 ## Primary Review Cues (Fast Skim)
 
-Please review implementation commit:
+Please review:
 
-`3a3d39838f93b50ec7d76074bf68d825d2f7e523`
-
-Focus areas:
-
-- Bow-tie messaging structure and intent
-- Network module additions and relationships
+- `ontologies/modules/messaging/beast_messaging_core.ttl`
+- `ontologies/modules/network/beast_network_core.ttl`
+- Related messaging/network SHACL constructs
 - Alignment with mailbox-core semantics
 
 ## Implementation Anchor
 
 Primary commit implementing this work:
 
-- 3a3d39838f93b50ec7d76074bf68d825d2f7e523  
+- 3a3d398  
   "Add bow-tie messaging + network modules and enrich with beast-mailbox-core semantics"
 
 ## Traceability Map
 
-| Concept                             | Commit                                       |
-|-------------------------------------|----------------------------------------------|
-| Bow-tie messaging constructs        | 3a3d39838f93b50ec7d76074bf68d825d2f7e523     |
-| Network module additions            | 3a3d39838f93b50ec7d76074bf68d825d2f7e523     |
-| Mailbox-core semantic alignment     | 3a3d39838f93b50ec7d76074bf68d825d2f7e523     |
+| Concept                          | Commit   | Files |
+|----------------------------------|----------|-------|
+| Bow-tie messaging constructs     | 3a3d398  | ontologies/modules/messaging/beast_messaging_core.ttl |
+| Network module additions         | 3a3d398  | ontologies/modules/network/beast_network_core.ttl |
+| Mailbox-core semantic alignment  | 3a3d398  | ontologies/modules/messaging/beast_messaging_core.ttl |
 
-This document links the conceptual Issue directly to its specific implementation commit reference.
+This document links the conceptual Issue to its specific implementation commit and associated ontology modules.

--- a/docs/traceability/issue-9-bowtie-messaging.md
+++ b/docs/traceability/issue-9-bowtie-messaging.md
@@ -1,36 +1,52 @@
-# Issue #9: Bow-tie messaging + network modules
+# Issue #9: Bow-Tie messaging + network modules
 
 ## Intent
-Introduce a “bow-tie” messaging structure and associated network modules, enriched to align with beast-mailbox-core semantics for clearer message flow modeling and modularity.
+
+Document the bow-tie messaging and network module enhancements previously implemented in the referenced commit, ensuring clear traceability between the conceptual messaging architecture and its concrete implementation.
 
 ## Context
-As messaging capabilities expanded, we needed a more organized semantic structure to represent:
-- messaging flow patterns
-- network-related concepts
-- consistent alignment with mailbox semantics (beast-mailbox-core)
 
-This improves reasoning clarity and keeps messaging components modular and reviewable.
+As Beast Mode messaging evolved, the system required a more structured representation of message flow, network semantics, and alignment with mailbox-core concepts. The referenced implementation commit introduces bow-tie messaging constructs and associated network modules to formalize these semantics.
 
 ## What Changed (Implementation Summary)
-- Added/organized bow-tie messaging module(s)
-- Added/organized network module(s)
-- Enriched messaging semantics to align with beast-mailbox-core concepts
-- Added/updated any associated validation constraints (if applicable)
+
+The referenced implementation commit:
+
+`3a3d39838f93b50ec7d76074bf68d825d2f7e523`
+
+Introduces:
+
+- Bow-tie messaging constructs for structured message flow modeling
+- Network module additions aligned with messaging semantics
+- Enrichment and alignment with beast-mailbox-core concepts
+
+This PR adds traceability documentation only and does not modify ontology logic.
 
 ## Primary Review Cues (Fast Skim)
-Please focus on:
-- Ontology module(s) defining bow-tie messaging structure
-- Network module(s) introduced/updated alongside messaging
-- Places where mailbox semantics are referenced/enriched
-- Any SHACL shapes validating messaging/network structure (if present)
+
+Please review implementation commit:
+
+`3a3d39838f93b50ec7d76074bf68d825d2f7e523`
+
+Focus areas:
+
+- Bow-tie messaging structure and intent
+- Network module additions and relationships
+- Alignment with mailbox-core semantics
 
 ## Implementation Anchor
+
 Primary commit implementing this work:
 
-- 3a3d398  
+- 3a3d39838f93b50ec7d76074bf68d825d2f7e523  
   "Add bow-tie messaging + network modules and enrich with beast-mailbox-core semantics"
 
 ## Traceability Map
-Issue → Concept → Commit → Files
 
-This document exists to make review fast and to map Issue #9 to its implementation anchor.
+| Concept                             | Commit                                       |
+|-------------------------------------|----------------------------------------------|
+| Bow-tie messaging constructs        | 3a3d39838f93b50ec7d76074bf68d825d2f7e523     |
+| Network module additions            | 3a3d39838f93b50ec7d76074bf68d825d2f7e523     |
+| Mailbox-core semantic alignment     | 3a3d39838f93b50ec7d76074bf68d825d2f7e523     |
+
+This document links the conceptual Issue directly to its specific implementation commit reference.

--- a/docs/traceability/issue-9-bowtie-messaging.md
+++ b/docs/traceability/issue-9-bowtie-messaging.md
@@ -25,6 +25,7 @@ Please review:
 - `ontologies/modules/messaging/beast_messaging_core.ttl`
 - `ontologies/modules/network/beast_network_core.ttl`
 - `ontologies/modules/messaging/beast_a2a_shapes.ttl`
+- `ontologies/modules/messaging/beast_a2a_channel_impl.ttl`
 - `ontologies/modules/messaging/beast_mailbox_impl.ttl`
 - `ontologies/alignments/beast_mailbox_alignment.ttl`
 
@@ -48,6 +49,7 @@ Primary commit implementing this work:
 |-------------------------------------|----------|-------|
 | Bow-tie messaging constructs        | 3a3d398  | ontologies/modules/messaging/beast_messaging_core.ttl |
 | Network module additions            | 3a3d398  | ontologies/modules/network/beast_network_core.ttl |
+| A2A channel + AgentCard implementation | 3a3d398  | ontologies/modules/messaging/beast_a2a_channel_impl.ttl |
 | Messaging SHACL validation shapes   | 3a3d398  | ontologies/modules/messaging/beast_a2a_shapes.ttl |
 | Mailbox implementation alignment    | 3a3d398  | ontologies/modules/messaging/beast_mailbox_impl.ttl |
 | Mailbox semantic alignment mapping  | 3a3d398  | ontologies/alignments/beast_mailbox_alignment.ttl |

--- a/docs/traceability/issue-9-bowtie-messaging.md
+++ b/docs/traceability/issue-9-bowtie-messaging.md
@@ -6,7 +6,7 @@ Document the bow-tie messaging and network module enhancements implemented in th
 
 ## Context
 
-As Beast Mode messaging evolved, the system required a more structured representation of message flow, network semantics, and alignment with mailbox-core concepts. The referenced implementation formalizes these constructs within dedicated messaging and network modules.
+As Beast Mode messaging evolved, the system required a more structured representation of message flow, network semantics, and alignment with mailbox-core concepts. The referenced implementation formalizes messaging and network constructs and introduces mailbox alignment scaffolding.
 
 ## What Changed (Implementation Summary)
 
@@ -14,7 +14,10 @@ The referenced implementation introduces:
 
 - Bow-tie messaging constructs for structured message flow modeling
 - Network module additions aligned with messaging semantics
-- Enrichment and alignment with mailbox-core concepts
+- A2A channel + AgentCard implementation constructs
+- Mailbox-core alignment scaffolding (equivalence mappings pending vocabulary confirmation)
+
+Note: `ontologies/alignments/beast_mailbox_alignment.ttl` currently provides alignment scaffolding only. The `owl:equivalentClass` / `owl:equivalentProperty` mappings remain commented out pending confirmation of the beast-mailbox-core vocabulary and namespace.
 
 This PR adds traceability documentation only and does not modify ontology logic.
 
@@ -24,8 +27,8 @@ Please review:
 
 - `ontologies/modules/messaging/beast_messaging_core.ttl`
 - `ontologies/modules/network/beast_network_core.ttl`
-- `ontologies/modules/messaging/beast_a2a_shapes.ttl`
 - `ontologies/modules/messaging/beast_a2a_channel_impl.ttl`
+- `ontologies/modules/messaging/beast_a2a_shapes.ttl`
 - `ontologies/modules/messaging/beast_mailbox_impl.ttl`
 - `ontologies/alignments/beast_mailbox_alignment.ttl`
 
@@ -33,8 +36,9 @@ Focus on:
 
 - Bow-tie messaging structure
 - Network module relationships
+- A2A channel + AgentCard constructs and associated skills/properties
 - SHACL validation shapes related to messaging
-- Mailbox-core semantic alignment
+- Mailbox-core alignment scaffolding and intended equivalence points
 
 ## Implementation Anchor
 
@@ -45,13 +49,13 @@ Primary commit implementing this work:
 
 ## Traceability Map
 
-| Concept                             | Commit   | Files |
-|-------------------------------------|----------|-------|
-| Bow-tie messaging constructs        | 3a3d398  | ontologies/modules/messaging/beast_messaging_core.ttl |
-| Network module additions            | 3a3d398  | ontologies/modules/network/beast_network_core.ttl |
-| A2A channel + AgentCard implementation | 3a3d398  | ontologies/modules/messaging/beast_a2a_channel_impl.ttl |
-| Messaging SHACL validation shapes   | 3a3d398  | ontologies/modules/messaging/beast_a2a_shapes.ttl |
-| Mailbox implementation alignment    | 3a3d398  | ontologies/modules/messaging/beast_mailbox_impl.ttl |
-| Mailbox semantic alignment mapping  | 3a3d398  | ontologies/alignments/beast_mailbox_alignment.ttl |
+| Concept                                        | Commit   | Files |
+|------------------------------------------------|----------|-------|
+| Bow-tie messaging constructs                  | 3a3d398  | ontologies/modules/messaging/beast_messaging_core.ttl |
+| Network module additions                      | 3a3d398  | ontologies/modules/network/beast_network_core.ttl |
+| A2A channel + AgentCard implementation        | 3a3d398  | ontologies/modules/messaging/beast_a2a_channel_impl.ttl |
+| Messaging SHACL validation shapes             | 3a3d398  | ontologies/modules/messaging/beast_a2a_shapes.ttl |
+| Mailbox implementation alignment constructs   | 3a3d398  | ontologies/modules/messaging/beast_mailbox_impl.ttl |
+| Mailbox semantic alignment scaffolding (WIP)  | 3a3d398  | ontologies/alignments/beast_mailbox_alignment.ttl |
 
 This document links the conceptual Issue to its specific implementation commit and associated ontology modules.

--- a/docs/traceability/issue-9-bowtie-messaging.md
+++ b/docs/traceability/issue-9-bowtie-messaging.md
@@ -49,13 +49,13 @@ Primary commit implementing this work:
 
 ## Traceability Map
 
-| Concept                                        | Commit   | Files |
-|------------------------------------------------|----------|-------|
-| Bow-tie messaging constructs                  | 3a3d398  | ontologies/modules/messaging/beast_messaging_core.ttl |
-| Network module additions                      | 3a3d398  | ontologies/modules/network/beast_network_core.ttl |
-| A2A channel + AgentCard implementation        | 3a3d398  | ontologies/modules/messaging/beast_a2a_channel_impl.ttl |
-| Messaging SHACL validation shapes             | 3a3d398  | ontologies/modules/messaging/beast_a2a_shapes.ttl |
-| Mailbox implementation alignment constructs   | 3a3d398  | ontologies/modules/messaging/beast_mailbox_impl.ttl |
-| Mailbox semantic alignment scaffolding (WIP)  | 3a3d398  | ontologies/alignments/beast_mailbox_alignment.ttl |
+| Concept | Commit | Files |
+|---|---|---|
+| Bow-tie messaging constructs | 3a3d398 | ontologies/modules/messaging/beast_messaging_core.ttl |
+| Network module additions | 3a3d398 | ontologies/modules/network/beast_network_core.ttl |
+| A2A channel + AgentCard implementation | 3a3d398 | ontologies/modules/messaging/beast_a2a_channel_impl.ttl |
+| Messaging SHACL validation shapes | 3a3d398 | ontologies/modules/messaging/beast_a2a_shapes.ttl |
+| Mailbox implementation alignment constructs | 3a3d398 | ontologies/modules/messaging/beast_mailbox_impl.ttl |
+| Mailbox semantic alignment scaffolding (WIP) | 3a3d398 | ontologies/alignments/beast_mailbox_alignment.ttl |
 
 This document links the conceptual Issue to its specific implementation commit and associated ontology modules.

--- a/docs/traceability/issue-9-bowtie-messaging.md
+++ b/docs/traceability/issue-9-bowtie-messaging.md
@@ -14,7 +14,7 @@ The referenced implementation introduces:
 
 - Bow-tie messaging constructs for structured message flow modeling
 - Network module additions aligned with messaging semantics
-- Enrichment and alignment with beast-mailbox-core concepts
+- Enrichment and alignment with mailbox-core concepts
 
 This PR adds traceability documentation only and does not modify ontology logic.
 
@@ -24,8 +24,16 @@ Please review:
 
 - `ontologies/modules/messaging/beast_messaging_core.ttl`
 - `ontologies/modules/network/beast_network_core.ttl`
-- Related messaging/network SHACL constructs
-- Alignment with mailbox-core semantics
+- `ontologies/modules/messaging/beast_a2a_shapes.ttl`
+- `ontologies/modules/messaging/beast_mailbox_impl.ttl`
+- `ontologies/alignments/beast_mailbox_alignment.ttl`
+
+Focus on:
+
+- Bow-tie messaging structure
+- Network module relationships
+- SHACL validation shapes related to messaging
+- Mailbox-core semantic alignment
 
 ## Implementation Anchor
 
@@ -36,10 +44,12 @@ Primary commit implementing this work:
 
 ## Traceability Map
 
-| Concept                          | Commit   | Files |
-|----------------------------------|----------|-------|
-| Bow-tie messaging constructs     | 3a3d398  | ontologies/modules/messaging/beast_messaging_core.ttl |
-| Network module additions         | 3a3d398  | ontologies/modules/network/beast_network_core.ttl |
-| Mailbox-core semantic alignment  | 3a3d398  | ontologies/modules/messaging/beast_messaging_core.ttl |
+| Concept                             | Commit   | Files |
+|-------------------------------------|----------|-------|
+| Bow-tie messaging constructs        | 3a3d398  | ontologies/modules/messaging/beast_messaging_core.ttl |
+| Network module additions            | 3a3d398  | ontologies/modules/network/beast_network_core.ttl |
+| Messaging SHACL validation shapes   | 3a3d398  | ontologies/modules/messaging/beast_a2a_shapes.ttl |
+| Mailbox implementation alignment    | 3a3d398  | ontologies/modules/messaging/beast_mailbox_impl.ttl |
+| Mailbox semantic alignment mapping  | 3a3d398  | ontologies/alignments/beast_mailbox_alignment.ttl |
 
 This document links the conceptual Issue to its specific implementation commit and associated ontology modules.


### PR DESCRIPTION
Closes #9

## Intent
Provide traceability between Issue #9 and the implementation of the bow-tie messaging + network module structure aligned with beast-mailbox-core semantics.

This PR does not modify ontology logic. It adds structured review notes pointing directly to the implementation anchor.

## What this PR adds
- docs/traceability/issue-9-bowtie-messaging.md
- Implementation anchor: commit 3a3d398

## Review cues (fast skim)
- Bow-tie messaging module(s)
- Network module(s)
- Mailbox semantic alignment
- Any related SHACL validation logic