### PR TITLE
docs: add global traceability index for Beast Mode ontology

### DIFF
--- a/docs/traceability/TRACEABILITY_INDEX.md
+++ b/docs/traceability/TRACEABILITY_INDEX.md
@@ -1,0 +1,61 @@
+# Beast Mode Ontology – Traceability Index
+
+This document provides a high-level map from conceptual Issues to implementation anchors (commits) and traceability notes.
+
+It exists to support fast architectural review and long-term governance.
+
+---
+
+## Issue #1 — Core Capability Inference
+- Concept: Derive Agent capabilities from supported Tasks (inference chain)
+- Implementation Anchor: ceebfa4
+- Traceability Doc: docs/traceability/issue-1-core-capability-inference.md
+
+---
+
+## Issue #3 — Trust Extension
+- Concept: Trust modeling module with SHACL validation
+- Implementation Anchor: 0657661
+- Traceability Doc: docs/traceability/issue-3-trust-extension.md
+
+---
+
+## Issue #5 — A2A Edge Transport + AgentCard
+- Concept: Interoperability transport + semantic discovery projection
+- Implementation Anchor: fb7717d
+- Traceability Doc: docs/traceability/issue-5-a2a-edge-transport.md
+
+---
+
+## Issue #7 — SHACL Rule + dcterms Alignment
+- Concept: Validation correction and datatype alignment
+- Implementation Anchor: c79cec4
+- Traceability Doc: docs/traceability/issue-7-shacl-rule-dcterms.md
+
+---
+
+## Issue #9 — Bow-Tie Messaging + Network Modules
+- Concept: Structured messaging/network semantics aligned with mailbox-core
+- Implementation Anchor: 3a3d398
+- Traceability Doc: docs/traceability/issue-9-bowtie-messaging.md
+
+---
+
+## Issue #11 — Specialty + Disagreement Modeling
+- Concept: Specialty constructs and structured disagreement semantics
+- Implementation Anchor: 7b8d6d7
+- Traceability Doc: docs/traceability/issue-11-specialty-disagreement.md
+
+---
+
+## Traceability Pattern
+
+Each major conceptual change follows:
+
+Issue → Traceability PR → Implementation Anchor → Ontology Files
+
+This ensures:
+- Review clarity
+- Architectural transparency
+- Long-term maintainability
+- Governance alignment

--- a/docs/traceability/TRACEABILITY_INDEX.md
+++ b/docs/traceability/TRACEABILITY_INDEX.md
@@ -7,7 +7,8 @@ It exists to support fast architectural review and long-term governance.
 ---
 
 ## Issue #1 — Core Capability Inference
-- Concept: Derive Agent capabilities from supported Tasks (inference chain)
+- Core structure: Agent → Capability → Task
+- Inference pattern: Agent supporting a Task can be used to infer/ validate required Capabilities
 - Implementation Anchor: ceebfa4
 - Traceability Doc: docs/traceability/issue-1-core-capability-inference.md
 
@@ -16,35 +17,35 @@ It exists to support fast architectural review and long-term governance.
 ## Issue #3 — Trust Extension
 - Concept: Trust modeling module with SHACL validation
 - Implementation Anchor: 0657661
-- Traceability Doc: docs/traceability/issue-3-trust-extension.md
+- Traceability Doc: Traceability Doc: pending merge (see PR for Issue #3 traceability)
 
 ---
 
 ## Issue #5 — A2A Edge Transport + AgentCard
 - Concept: Interoperability transport + semantic discovery projection
 - Implementation Anchor: fb7717d
-- Traceability Doc: docs/traceability/issue-5-a2a-edge-transport.md
+- Traceability Doc: Traceability Doc: pending merge (see PR for Issue #5 traceability)
 
 ---
 
 ## Issue #7 — SHACL Rule + dcterms Alignment
 - Concept: Validation correction and datatype alignment
 - Implementation Anchor: c79cec4
-- Traceability Doc: docs/traceability/issue-7-shacl-rule-dcterms.md
+- Traceability Doc: Traceability Doc: pending merge (see PR for Issue #7 traceability)
 
 ---
 
 ## Issue #9 — Bow-Tie Messaging + Network Modules
 - Concept: Structured messaging/network semantics aligned with mailbox-core
 - Implementation Anchor: 3a3d398
-- Traceability Doc: docs/traceability/issue-9-bowtie-messaging.md
+- Traceability Doc: Traceability Doc: pending merge (see PR for Issue #9 traceability)
 
 ---
 
 ## Issue #11 — Specialty + Disagreement Modeling
 - Concept: Specialty constructs and structured disagreement semantics
 - Implementation Anchor: 7b8d6d7
-- Traceability Doc: docs/traceability/issue-11-specialty-disagreement.md
+- Traceability Doc: Traceability Doc: pending merge (see PR for Issue #11 traceability)
 
 ---
 

--- a/docs/traceability/issue-1-core-capability-inference.md
+++ b/docs/traceability/issue-1-core-capability-inference.md
@@ -1,0 +1,50 @@
+# Issue #1: Core capability inference
+
+## Intent
+Formalize a capability inference pattern that ensures Agent capability assertions remain consistent with Task requirements.
+
+## Core Structure vs Inference
+
+- Core ontological structure: **Agent → Capability → Task**
+- Inference / validation pattern: if an Agent is modeled as supporting a Task, and that Task requires a Capability, then the Agent can be inferred or validated to have that Capability.
+
+The fundamental structure flows from Agent to Capability to Task.  
+The Task-based reasoning path is a validation/inference mechanism, not the primary ontological chain.
+
+## Context
+As the Beast Mode ontology evolved, we formalized:
+
+- Capability assets
+- Agent–Capability–Task relationships
+- Constraints ensuring consistency between declared Task support and Capability assertions
+
+This prevents semantic drift between Task modeling and Agent capability claims.
+
+## What Changed (Implementation Summary)
+- Core ontology updated to formalize:
+  - Capability asset modeling
+  - Agent–Capability–Task structural relationships
+  - Validation/inference alignment
+- SHACL constraints aligned to support consistent capability attribution
+- Example usage added where applicable
+
+## Primary Review Cues (Fast Skim)
+
+Please review:
+
+- Core ontology definitions governing Agent–Capability–Task relationships
+- SHACL shapes validating structural consistency
+- Example TTL demonstrating capability alignment
+
+## Implementation Anchor
+
+Primary commit implementing this work:
+
+- ceebfa4  
+  "Core ontology: formalize capability assets, inference chain, and discovery constraints"
+
+## Traceability Map
+
+Issue → Concept → Commit → Files
+
+This document exists to provide clear linkage between the conceptual issue and its concrete implementation anchor for rapid review.


### PR DESCRIPTION
## Intent
Add a high-level traceability index mapping conceptual Issues to implementation anchors and traceability notes.

## What this PR adds
- docs/traceability/TRACEABILITY_INDEX.md

## Purpose
Provide a single navigation point for:
Issue → Traceability PR → Commit → Ontology files

This improves review clarity, architectural transparency, and long-term governance.