### PR TITLE
docs: add traceability index (merge-order safe)

### DIFF
--- a/docs/traceability/TRACEABILITY_INDEX.md
+++ b/docs/traceability/TRACEABILITY_INDEX.md
@@ -1,0 +1,62 @@
+# Beast Mode Ontology – Traceability Index
+
+This document provides a high-level map from conceptual Issues to implementation anchors (commits) and traceability notes.
+
+It exists to support fast architectural review and long-term governance.
+
+---
+
+## Issue #1 — Core Capability Inference
+- Core structure: Agent → Capability → Task
+- Inference pattern: Agent supporting a Task can be used to infer/validate required Capabilities
+- Implementation Anchor: ceebfa4
+- Traceability Doc: docs/traceability/issue-1-core-capability-inference.md
+
+---
+
+## Issue #3 — Trust Extension
+- Concept: Trust modeling module with SHACL validation
+- Implementation Anchor: 0657661
+- Traceability Doc: pending merge (see PR for Issue #3 traceability)
+
+---
+
+## Issue #5 — A2A Edge Transport + AgentCard
+- Concept: Interoperability transport + semantic discovery projection
+- Implementation Anchor: fb7717d
+- Traceability Doc: pending merge (see PR for Issue #5 traceability)
+
+---
+
+## Issue #7 — SHACL Rule + dcterms Alignment
+- Concept: Validation correction and datatype alignment
+- Implementation Anchor: c79cec4
+- Traceability Doc: pending merge (see PR for Issue #7 traceability)
+
+---
+
+## Issue #9 — Bow-Tie Messaging + Network Modules
+- Concept: Structured messaging/network semantics aligned with mailbox-core
+- Implementation Anchor: 3a3d398
+- Traceability Doc: pending merge (see PR for Issue #9 traceability)
+
+---
+
+## Issue #11 — Specialty + Disagreement Modeling
+- Concept: Specialty constructs and structured disagreement semantics
+- Implementation Anchor: 7b8d6d7
+- Traceability Doc: pending merge (see PR for Issue #11 traceability)
+
+---
+
+## Traceability Pattern
+
+Each major conceptual change follows:
+
+Issue → Traceability PR → Implementation Anchor → Ontology Files
+
+This supports:
+- Review clarity
+- Architectural transparency
+- Long-term maintainability
+- Governance alignment


### PR DESCRIPTION
Adds a global traceability index mapping Issues to implementation anchors.

For traceability docs not yet merged into main, the index marks them as “pending merge” to avoid broken references during review.

No ontology logic changes.